### PR TITLE
Suppress test warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 100
+
+[tool:pytest]
+junit_family=xunit1


### PR DESCRIPTION
Adding this to suppress the following warning from `pytest`

```
=============================== warnings summary ===============================
venv/lib/python3.7/site-packages/_pytest/junitxml.py:417
  /home/itgi/Projects/reference-island/venv/lib/python3.7/site-packages/_pytest/junitxml.py:417: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)
```