### PR TITLE
Fix blacklisting external identifiers

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -75,6 +75,33 @@ blacklisted_properties:
     - P7457
     # End of Commons media data type:
 
+blacklisted_external_identifiers:
+    - P646  # Freebase
+    - P345  # IMDb
+    - P434
+    - P436
+    - P1953
+    - P1447
+    - P3138
+    - P2013
+    - P1954
+    - P2949
+    - P2600
+    - P535
+    - P480
+    - P5032
+    - P2638
+    - P905
+    - P5786
+    - P2346
+    - P435
+    - P4342
+    - P4947
+    - P2397
+    - P982
+    - P1651
+    - P4159
+
 data_storage_path:
     'data/'
 

--- a/tests/external_identifiers/test_generate_whitelisted_ext_ids.py
+++ b/tests/external_identifiers/test_generate_whitelisted_ext_ids.py
@@ -38,7 +38,7 @@ class MockStorage():
 
 class MockConfig():
     def get(self, key):
-        if key == 'blacklisted_properties':
+        if key == 'blacklisted_external_identifiers':
             return ['P3']
 
 

--- a/wikidatarefisland/external_identifiers/generate_whitelisted_ext_ids.py
+++ b/wikidatarefisland/external_identifiers/generate_whitelisted_ext_ids.py
@@ -67,7 +67,7 @@ class GenerateWhitelistedExtIds():
 
         pids = []
         for i in external_identifiers:
-            if i in final_results or i in self.config.get('blacklisted_properties'):
+            if i in final_results or i in self.config.get('blacklisted_external_identifiers'):
                 continue
             pids.append(i)
 


### PR DESCRIPTION
Currently, it skips properties that are blacklisted, like P31 while such
thing would never be needed as they are not external identifiers anyway.
The blacklisted external identifiers added from the list PM composed and
was added to prototype in https://github.com/wmde/reference-island/blob/prototype/wikidatarefisland/config.py#L11

Bug: T250795