### PR TITLE
Fix argument parsing

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -51,7 +51,7 @@ def test_main_ss1(monkeypatch, test_directory):
     monkeypatch.setattr(requests, "get", mock_get)
 
     test_filename = "test_result_ss1.json"
-    mock_args = f"--step ss1 --output {test_filename}"
+    mock_args = f"this_is_ignored.py --step ss1 --output {test_filename}"
     mock_file_path = test_directory.join('scripts', 'this_is_ignored.py')
     result_file = test_directory.join('data', test_filename)
 

--- a/wikidatarefisland/run.py
+++ b/wikidatarefisland/run.py
@@ -19,7 +19,7 @@ def main(argv, filepath):
     parser.add_argument('--output', default='output.json', dest='output_path', type=str,
                         help='File for the step to read output from')
 
-    args = parser.parse_args(argv)
+    args = parser.parse_args(argv[1:])
 
     # Services
     file_path = os.path.realpath(filepath)


### PR DESCRIPTION
The run script didn't run because we forgot to omit the first `argv`