### PR TITLE
Make Storage.getLines() method possible to read some JSON

### DIFF
--- a/tests/data_access/test_storage.py
+++ b/tests/data_access/test_storage.py
@@ -23,7 +23,27 @@ class TestStorage:
 
         assert storage.get("test.json") == json.loads(mock_file.read())
 
-    def test_getLines(self, tmpdir):
+    def test_getLines_json(self, tmpdir):
+        mock_lines = [
+            {"test": "hello"},
+            {"goodbye": "test"}
+        ]
+
+        mock_data = '''
+        [
+            {"test": "hello"},
+            {"goodbye": "test"}
+        ]
+        '''
+
+        mock_file = tmpdir.join('test.json')
+        mock_file.write(mock_data)
+
+        storage = Storage(tmpdir)
+
+        assert list(storage.getLines('test.json')) == mock_lines
+
+    def test_getLines_jsonl(self, tmpdir):
         mock_lines = [
             {"test": "hello"},
             {"goodbye": "test"}

--- a/wikidatarefisland/data_access/storage.py
+++ b/wikidatarefisland/data_access/storage.py
@@ -16,7 +16,8 @@ class Storage(object):
         with open(path, 'r') as f:
             for line in f:
                 try:
-                    yield json.loads(line)
+                    # TODO Fix this hack to make json behave a bit like jsonl: T251271
+                    yield json.loads(line.strip().strip(','))
                 except json.JSONDecodeError:
                     continue
 


### PR DESCRIPTION
We had assumed that getLines() would work to read some JSON
but this wasn't the case. Particularly the JSON "style"
that is present in the Wikidata dumps.

This patch adds a test to cover reading a snippet like this
and a very quick hack to make it work.