### PR TITLE
[Discussion] Update contract for Pipe 2

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -117,8 +117,8 @@ The format of the template of one row of Pipe 2 is as follows:
   "statement": {statementBlob},
   "itemId": [itemId],
   "reference": {
-    "url": [scrapedResourceURL],
-    "ext_idef_pid": [externalIdentifierPID]
+    "url": [referenceURL],
+    "ext_id_pid": [externalIdProp],
     "referenceMetadata": {referenceBlob},
     "extractedData": [ [value] ]
     }
@@ -133,6 +133,7 @@ Note this corresponds to the format of the referenceMetadata seen in [SS4](#ss-4
   *[statedInPropId]: [externalIdItem],
   *[externalIdProp]: [externalIdVal],
   *[referenceUrl]: [String], // This is optional
+  [dateRetrieved]: [String]
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -117,8 +117,10 @@ The format of the template of one row of Pipe 2 is as follows:
   "statement": {statementBlob},
   "itemId": [itemId],
   "reference": {
-    referenceMetadata: referenceBlob,
-    extractedData: [ [value] ]
+    "url": [scrapedResourceURL],
+    "ext_idef_pid": [externalIdentifierPID]
+    "referenceMetadata": {referenceBlob},
+    "extractedData": [ [value] ]
     }
 }
 ```
@@ -130,8 +132,7 @@ Note this corresponds to the format of the referenceMetadata seen in [SS4](#ss-4
 {
   *[statedInPropId]: [externalIdItem],
   *[externalIdProp]: [externalIdVal],
-  *[referenceUrl]: [String],
-  [dateRetrieved]: [String]
+  *[referenceUrl]: [String], // This is optional
 }
 ```
 


### PR DESCRIPTION
As mentioned in [T252640](https://phabricator.wikimedia.org/T252640) This pull request is meant as a discussion on how to update the contract for pipe 2.

* I updated the output of pipe 2 to include the url (in the upper level, for simplicity of access)
* I also added another property at the top level for the External Identfier PID, as I noticed a repeating pattern in our codebase to try and extract it from the `referenceMetadata`. Therefore, easier access to this would simplify our code in a substantial way. See [comment on PR #39](https://github.com/wmde/reference-island/pull/39#discussion_r423728863) and [T252718](https://phabricator.wikimedia.org/T252718).