### PR TITLE
Sync populator script with toolforge

### DIFF
--- a/wikidata_game/populator.php
+++ b/wikidata_game/populator.php
@@ -19,7 +19,7 @@ function backupTable($dbhost, $dbname) {
 
 $db = getDb($dbhost, $dbname);
 $file_path = getenv('REFS_PATH');
-$data = explode( "\n", file_get_contents($file_path) );
+$data = json_decode(file_get_contents($file_path), true);
 backupTable($dbhost, $dbname);
 $db->query("TRUNCATE TABLE refs;")->execute();
 $sql = "INSERT INTO refs (ref_data) VALUES (?)";


### PR DESCRIPTION
While working on [T252856](https://phabricator.wikimedia.org/T252856) I noticed that the populator script present there is different that the one on our repo. Since I replaced the version there with a symlink to this file, the versions must match.