### PR TITLE
Improve reading from and writing to dumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ data/whitelisted_ext_idefs.json:
 	python3 wikidatarefisland/run.py --step ss1 --output "whitelisted_ext_idefs.json"
 data/extracted_unreferenced_statements.jsonl: \
 	data/whitelisted_ext_idefs.json
-	python3 wikidatarefisland/run.py --step extract_items --side-service-input "whitelisted_ext_idefs.json" --input "${DUMP_PATH}" --output "extracted_unreferenced_statements.jsonl"
+	python3 wikidatarefisland/run.py --step extract_items --side-service-input "whitelisted_ext_idefs.json" --dump-path "${DUMP_PATH}" --output "extracted_unreferenced_statements.jsonl"
 data/schema_org_context.jsonld:
 	python3 wikidatarefisland/run.py --step fetch_schema_ctx --output "schema_org_context.jsonld"
 data/scraped_data.jsonl: \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ data/whitelisted_ext_idefs.json:
 	python3 wikidatarefisland/run.py --step ss1 --output "whitelisted_ext_idefs.json"
 data/extracted_unreferenced_statements.jsonl: \
 	data/whitelisted_ext_idefs.json
-	python3 wikidatarefisland/run.py --step extract_items --side-service-input "whitelisted_ext_idefs.json" --input "dump.json" --output "extracted_unreferenced_statements.jsonl"
+	python3 wikidatarefisland/run.py --step extract_items --side-service-input "whitelisted_ext_idefs.json" --input "${DUMP_PATH}" --output "extracted_unreferenced_statements.jsonl"
 data/schema_org_context.jsonld:
 	python3 wikidatarefisland/run.py --step fetch_schema_ctx --output "schema_org_context.jsonld"
 data/scraped_data.jsonl: \

--- a/tests/data_access/test_storage.py
+++ b/tests/data_access/test_storage.py
@@ -1,3 +1,5 @@
+import bz2
+import gzip
 import json
 import os
 
@@ -23,7 +25,7 @@ class TestStorage:
 
         assert storage.get("test.json") == json.loads(mock_file.read())
 
-    def test_getLines_json(self, tmpdir):
+    def test_get_dump_lines_json(self, tmpdir):
         mock_lines = [
             {"test": "hello"},
             {"goodbye": "test"}
@@ -38,10 +40,52 @@ class TestStorage:
 
         mock_file = tmpdir.join('test.json')
         mock_file.write(mock_data)
+        path = os.path.join(tmpdir, 'test.json')
 
         storage = Storage(tmpdir)
 
-        assert list(storage.getLines('test.json')) == mock_lines
+        assert list(storage.get_dump_lines(path)) == mock_lines
+
+    def test_get_dump_lines_gz(self, tmpdir):
+        mock_lines = [
+            {"test": "hello"},
+            {"goodbye": "test"}
+        ]
+
+        mock_data = '''
+        [
+            {"test": "hello"},
+            {"goodbye": "test"}
+        ]
+        '''
+        path = os.path.join(tmpdir, 'test.json.gz')
+        with gzip.open(path, 'w') as f:
+            f.write(bytes(mock_data, 'utf-8'))
+
+        storage = Storage(tmpdir)
+
+        assert list(storage.get_dump_lines(path)) == mock_lines
+
+    def test_get_dump_lines_bz2(self, tmpdir):
+        mock_lines = [
+            {"test": "hello"},
+            {"goodbye": "test"}
+        ]
+
+        mock_data = '''
+            [
+                {"test": "hello"},
+                {"goodbye": "test"}
+            ]
+            '''
+
+        path = os.path.join(tmpdir, 'test.json.bz2')
+        with bz2.open(path, 'w') as f:
+            f.write(bytes(mock_data, 'utf-8'))
+
+        storage = Storage(tmpdir)
+
+        assert list(storage.get_dump_lines(path)) == mock_lines
 
     def test_getLines_jsonl(self, tmpdir):
         mock_lines = [

--- a/tests/data_access/test_storage.py
+++ b/tests/data_access/test_storage.py
@@ -115,12 +115,12 @@ class TestStorage:
 
     def test_append_raw(self, tmpdir):
         mock_file = tmpdir.join('test.txt')
-        mock_file.write('Hello ')
+        mock_file.write('Hello')
 
         storage = Storage(tmpdir)
         storage.append('test.txt', 'Goodbye', True)
 
-        assert mock_file.read() == 'Hello Goodbye'
+        assert mock_file.read() == 'Hello\nGoodbye'
 
     def test_append_json(self, tmpdir):
         mock_lines = [

--- a/tests/pumps/test_pumps.py
+++ b/tests/pumps/test_pumps.py
@@ -12,6 +12,7 @@ mock_output_file_path = 'output_file_path'
 class MockStorage():
     def __init__(self):
         self.mock_output_file_content = ''
+        self.append_func_call = 0
 
     def getLines(self, input_file_name):
         assert input_file_name == mock_input_file_path, 'should pass input file name to Storage'
@@ -22,11 +23,13 @@ class MockStorage():
         return [mock_input_data]*3
 
     def append(self, output_file_name, data, raw=False):
+        self.append_func_call += 1
         assert output_file_name == mock_output_file_path, 'should pass output file name to Storage'
         if not raw:
             self.mock_output_file_content += json.dumps(data)
         else:
-            self.mock_output_file_content += data + '\n'
+            self.mock_output_file_content += data
+        self.mock_output_file_content += '\n'
 
 
 class MockPipe(AbstractPipe):
@@ -40,7 +43,7 @@ def test_simple_pump():
     pump = SimplePump(mock_storage)
     pipe = MockPipe()
     pump.run(pipe, mock_input_file_path, mock_output_file_path)
-    assert mock_storage.mock_output_file_content == json.dumps(mock_output_data)
+    assert mock_storage.mock_output_file_content == json.dumps(mock_output_data) + '\n'
 
 
 def test_dump_reader_pump():
@@ -59,4 +62,5 @@ def test_dump_reader_pump_batch():
     pipe = MockPipe()
     pump.run(pipe, mock_input_file_path, mock_output_file_path)
     assert mock_storage.mock_output_file_content.strip() == \
-        '\n'.join([json.dumps(mock_output_data)] * batch_size)
+        '\n'.join([json.dumps(mock_output_data)] * 3)
+    assert mock_storage.append_func_call == 2

--- a/tests/pumps/test_pumps.py
+++ b/tests/pumps/test_pumps.py
@@ -1,7 +1,7 @@
 import json
 
 from wikidatarefisland.pipes import AbstractPipe
-from wikidatarefisland.pumps import SimplePump
+from wikidatarefisland.pumps import DumpReaderPump, SimplePump
 
 mock_input_data = {'mock': 'inputdata'}
 mock_output_data = {'mock': 'outputdata'}
@@ -17,9 +17,16 @@ class MockStorage():
         assert input_file_name == mock_input_file_path, 'should pass input file name to Storage'
         return [mock_input_data]
 
-    def append(self, output_file_name, data):
+    def get_dump_lines(self, input_file_name):
+        assert input_file_name == mock_input_file_path, 'should pass input file name to Storage'
+        return [mock_input_data]*3
+
+    def append(self, output_file_name, data, raw=False):
         assert output_file_name == mock_output_file_path, 'should pass output file name to Storage'
-        self.mock_output_file_content += json.dumps(data)
+        if not raw:
+            self.mock_output_file_content += json.dumps(data)
+        else:
+            self.mock_output_file_content += data + '\n'
 
 
 class MockPipe(AbstractPipe):
@@ -34,3 +41,22 @@ def test_simple_pump():
     pipe = MockPipe()
     pump.run(pipe, mock_input_file_path, mock_output_file_path)
     assert mock_storage.mock_output_file_content == json.dumps(mock_output_data)
+
+
+def test_dump_reader_pump():
+    mock_storage = MockStorage()
+    pump = DumpReaderPump(mock_storage, 1)
+    pipe = MockPipe()
+    pump.run(pipe, mock_input_file_path, mock_output_file_path)
+    assert mock_storage.mock_output_file_content.strip() == \
+        '\n'.join([json.dumps(mock_output_data)] * 3)
+
+
+def test_dump_reader_pump_batch():
+    mock_storage = MockStorage()
+    batch_size = 2
+    pump = DumpReaderPump(mock_storage, batch_size)
+    pipe = MockPipe()
+    pump.run(pipe, mock_input_file_path, mock_output_file_path)
+    assert mock_storage.mock_output_file_content.strip() == \
+        '\n'.join([json.dumps(mock_output_data)] * batch_size)

--- a/tests/pumps/test_pumps.py
+++ b/tests/pumps/test_pumps.py
@@ -20,7 +20,7 @@ class MockStorage():
 
     def get_dump_lines(self, input_file_name):
         assert input_file_name == mock_input_file_path, 'should pass input file name to Storage'
-        return [mock_input_data]*3
+        return [mock_input_data]*50
 
     def append(self, output_file_name, data, raw=False):
         self.append_func_call += 1
@@ -52,15 +52,16 @@ def test_dump_reader_pump():
     pipe = MockPipe()
     pump.run(pipe, mock_input_file_path, mock_output_file_path)
     assert mock_storage.mock_output_file_content.strip() == \
-        '\n'.join([json.dumps(mock_output_data)] * 3)
+        '\n'.join([json.dumps(mock_output_data)] * 50)
 
 
 def test_dump_reader_pump_batch():
     mock_storage = MockStorage()
-    batch_size = 2
+    batch_size = 9
     pump = DumpReaderPump(mock_storage, batch_size)
     pipe = MockPipe()
     pump.run(pipe, mock_input_file_path, mock_output_file_path)
     assert mock_storage.mock_output_file_content.strip() == \
-        '\n'.join([json.dumps(mock_output_data)] * 3)
-    assert mock_storage.append_func_call == 2
+        '\n'.join([json.dumps(mock_output_data)] * 50)
+    # five times for each batch, once to flush out the rest
+    assert mock_storage.append_func_call == 6

--- a/wikidatarefisland/data_access/storage.py
+++ b/wikidatarefisland/data_access/storage.py
@@ -52,11 +52,11 @@ class Storage(object):
     def append(self, file_, value, raw=False):
         path = os.path.join(self.path, file_)
         with open(path, 'a') as f:
+            # Add newline if file is not empty
+            new_line = '\n' if os.stat(f.name).st_size else ''
             if raw:
-                f.write(value)
+                f.write(new_line + value)
             else:
-                # Add newline if file is not empty
-                new_line = '\n' if os.stat(f.name).st_size else ''
                 f.write(new_line + json.dumps(value, ensure_ascii=False))
 
     @classmethod

--- a/wikidatarefisland/data_access/storage.py
+++ b/wikidatarefisland/data_access/storage.py
@@ -1,3 +1,5 @@
+import bz2
+import gzip
 import json
 import os
 
@@ -15,11 +17,29 @@ class Storage(object):
         path = os.path.join(self.path, file_)
         with open(path, 'r') as f:
             for line in f:
+                yield json.loads(line.strip())
+
+    def get_dump_lines(self, path):
+        mode = 'r'
+        file_ = os.path.split(path)[-1]
+        if file_.endswith('.gz'):
+            f = gzip.open(path, mode)
+        elif file_.endswith('.bz2'):
+            f = bz2.BZ2File(path, mode)
+        elif file_.endswith('.json'):
+            f = open(path, mode)
+        else:
+            raise NotImplementedError(f'Reading file {file_} is not supported')
+        try:
+            for line in f:
+                if isinstance(line, bytes):
+                    line = line.decode('utf-8')
                 try:
-                    # TODO Fix this hack to make json behave a bit like jsonl: T251271
                     yield json.loads(line.strip().strip(','))
                 except json.JSONDecodeError:
                     continue
+        finally:
+            f.close()
 
     def store(self, file_, value, raw=False):
         path = os.path.join(self.path, file_)

--- a/wikidatarefisland/pumps/__init__.py
+++ b/wikidatarefisland/pumps/__init__.py
@@ -1,3 +1,3 @@
-from .pump import AbstractPump, ObserverPump, SimplePump
+from .pump import AbstractPump, DumpReaderPump, ObserverPump, SimplePump
 
-__all__ = ["AbstractPump", "SimplePump", "ObserverPump"]
+__all__ = ["AbstractPump", "DumpReaderPump", "SimplePump", "ObserverPump"]

--- a/wikidatarefisland/pumps/pump.py
+++ b/wikidatarefisland/pumps/pump.py
@@ -36,6 +36,7 @@ class DumpReaderPump(AbstractPump):
                 if len(values) >= self.batch_size:
                     self.storage.append(output_file_path, '\n'.join(values), raw=True)
                     values = []
+        self.storage.append(output_file_path, '\n'.join(values), raw=True)
 
 
 class ObserverPump(AbstractPump):

--- a/wikidatarefisland/pumps/pump.py
+++ b/wikidatarefisland/pumps/pump.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 
 from wikidatarefisland.data_access import Storage
@@ -18,8 +19,23 @@ class SimplePump(AbstractPump):
         for line in self.storage.getLines(input_file_path):
             output = pipe.flow(line)
             for single_output in output:
-                # TODO: we're opening and closing this on every single line of output
                 self.storage.append(output_file_path, single_output)
+
+
+class DumpReaderPump(AbstractPump):
+    def __init__(self, storage: Storage, batch_size: int):
+        self.storage = storage
+        self.batch_size = batch_size
+
+    def run(self, pipe: AbstractPipe, input_file_path: str, output_file_path: str):
+        values = []
+        for line in self.storage.get_dump_lines(input_file_path):
+            output = pipe.flow(line)
+            for single_output in output:
+                values.append(json.dumps(single_output, ensure_ascii=False))
+                if len(values) >= self.batch_size:
+                    self.storage.append(output_file_path, '\n'.join(values), raw=True)
+                    values = []
 
 
 class ObserverPump(AbstractPump):

--- a/wikidatarefisland/run.py
+++ b/wikidatarefisland/run.py
@@ -27,6 +27,8 @@ def main(argv, filepath):
     parser.add_argument('--write-batch', default=20, dest='write_batch', type=int,
                         help='Batch size to write in the file, '
                              'choose bigger number if you have large memory')
+    parser.add_argument('--dump-path', dest='dump_path', type=str,
+                        help='Absolute path to the dump file')
 
     args = parser.parse_args(argv[1:])
 
@@ -58,7 +60,7 @@ def main(argv, filepath):
             config.get('blacklisted_item_classes'),
             config.get('ignored_reference_properties')
         )
-        dump_reader_pump.run(item_extractor, args.input_path, args.output_path)
+        dump_reader_pump.run(item_extractor, args.dump_path, args.output_path)
 
     if 'scrape' == args.step:
         schema_context = storage.get(args.side_service_input_path)

--- a/wikidatarefisland/run.py
+++ b/wikidatarefisland/run.py
@@ -5,7 +5,8 @@ import sys
 from wikidatarefisland import (Config, data_access, data_model,
                                external_identifiers, pipes, pumps, services)
 from wikidatarefisland.data_access import SchemaContextDownloader
-from wikidatarefisland.data_access.offline_document_loader import OfflineDocumentLoader
+from wikidatarefisland.data_access.offline_document_loader import \
+    OfflineDocumentLoader
 from wikidatarefisland.data_model import wikibase
 
 
@@ -23,6 +24,9 @@ def main(argv, filepath):
     parser.add_argument('--side-service-input', default='side_service_input.json',
                         dest='side_service_input_path', type=str,
                         help='Optional file for the step to read input from')
+    parser.add_argument('--write-batch', default=20, dest='write_batch', type=int,
+                        help='Batch size to write in the file, '
+                             'choose bigger number if you have large memory')
 
     args = parser.parse_args(argv[1:])
 
@@ -36,6 +40,7 @@ def main(argv, filepath):
 
     # Pumps
     simple_pump = pumps.SimplePump(storage)
+    dump_reader_pump = pumps.DumpReaderPump(storage, args.write_batch)
 
     if 'ss1' == args.step:
         ext_ids = external_identifiers.GenerateWhitelistedExtIds(
@@ -53,7 +58,7 @@ def main(argv, filepath):
             config.get('blacklisted_item_classes'),
             config.get('ignored_reference_properties')
         )
-        simple_pump.run(item_extractor, args.input_path, args.output_path)
+        dump_reader_pump.run(item_extractor, args.input_path, args.output_path)
 
     if 'scrape' == args.step:
         schema_context = storage.get(args.side_service_input_path)


### PR DESCRIPTION
 - Making the storage be able to read from the compressed dumps
 - Introduce DumpReaderPump to write to output in batches, making it
   around 30% faster
 - Decouple Storage.getLines() on reading from json and jsonlines.
   Making the code cleaner

Bug: T251863
Bug: T251271