### PR TITLE
Fix running the script in case simplejson is installed

### DIFF
--- a/wikidatarefisland/data_access/schema_context_downloader.py
+++ b/wikidatarefisland/data_access/schema_context_downloader.py
@@ -1,4 +1,7 @@
-from json import JSONDecodeError
+try:
+    from simplejson import JSONDecodeError
+except ImportError:
+    from json import JSONDecodeError
 import requests
 
 


### PR DESCRIPTION
This is a common pattern to handle soft dependencies. The requests
library does the same:
https://github.com/psf/requests/blob/bbc3d43522bcb1363050557655508d66bfebcfcf/requests/compat.py

Bug: T253728