### PR TITLE
Catch bad dates parsing in value_types

### DIFF
--- a/tests/data_model/wikibase/mock_data.py
+++ b/tests/data_model/wikibase/mock_data.py
@@ -41,6 +41,13 @@ mock = {
                     "time": '+1986-05-04T00:00:00Z',
                     "precision": 9
                 }
+            },
+            "invalid_date_day_precision": {
+                "datatype": 'time',
+                "value": {
+                    "time": '+1986-20-20T00:00:00Z',
+                    "precision": 11
+                }
             }
         },
         "with_globe-coordinate": {

--- a/tests/data_model/wikibase/test_value_types.py
+++ b/tests/data_model/wikibase/test_value_types.py
@@ -42,6 +42,13 @@ class TestDateTimeValue:
     def test_equivalence(self, statement, equivalent):
         assert DateTimeValue(statement) == equivalent
 
+    @pytest.mark.parametrize("statement,equivalent", [
+        (mock["statement"]["with_datetime"]["invalid_date_day_precision"], "+1986-05-04T00:00:00Z"),
+        (mock["statement"]["with_datetime"]["day_precision"], "+1986-20-20T00:00:00Z")
+    ])
+    def test_invalid_dates(self, statement, equivalent):
+        assert (DateTimeValue(statement) == equivalent) is False
+
 
 class TestGeoValue:
 

--- a/tests/data_model/wikibase/test_value_types.py
+++ b/tests/data_model/wikibase/test_value_types.py
@@ -44,9 +44,10 @@ class TestDateTimeValue:
 
     @pytest.mark.parametrize("statement,equivalent", [
         (mock["statement"]["with_datetime"]["invalid_date_day_precision"], "+1986-05-04T00:00:00Z"),
-        (mock["statement"]["with_datetime"]["day_precision"], "+1986-20-20T00:00:00Z")
+        (mock["statement"]["with_datetime"]["day_precision"], "+1986-20-20T00:00:00Z"),
+        (mock["statement"]["with_datetime"]["invalid_date_day_precision"], "+1986-20-20T00:00:00Z")
     ])
-    def test_invalid_dates(self, statement, equivalent):
+    def test_invalid_dates_returns_false_and_not_throws(self, statement, equivalent):
         assert (DateTimeValue(statement) == equivalent) is False
 
 

--- a/wikidatarefisland/data_model/wikibase/value_types.py
+++ b/wikidatarefisland/data_model/wikibase/value_types.py
@@ -79,6 +79,7 @@ class DateTimeValue:
         try:
             date = isoparse(self.value)
         except ValueError:
+            # Some Wikibase dates are not valid: https://phabricator.wikimedia.org/T85296
             return False
         return date.year == compare.year \
             and date.month == compare.month \

--- a/wikidatarefisland/data_model/wikibase/value_types.py
+++ b/wikidatarefisland/data_model/wikibase/value_types.py
@@ -76,7 +76,10 @@ class DateTimeValue:
             date = isoparse(self.value[:4])
             return date.year == compare.year
 
-        date = isoparse(self.value)
+        try:
+            date = isoparse(self.value)
+        except ValueError:
+            return False
         return date.year == compare.year \
             and date.month == compare.month \
             and date.day == compare.day


### PR DESCRIPTION
Return False when evaluating equality of an invalid Wikibase date.

Given that Wikibase doesn't ensure valid dates we must allow for
the possibility that we will be unable to parse them.

This patch specifically adresses invalid Wikibase day precision values.

It follows the existing pattern for failing to parse malformed foreign
values by not throwing and returning False.

It does not consider attempting to parse non-4 digit years

Bug: T254587