### PR TITLE
Enable accepted matches csv download

### DIFF
--- a/wikidata_game/stats.php
+++ b/wikidata_game/stats.php
@@ -4,9 +4,10 @@ require_once('includes/constants.php');
 require_once('includes/responses.php');
 require_once('includes/setup-db.php');
 
-if(isset($_GET['dump']) && $_GET['dump'] === 'rejected'){
-    $rejected = $getMatches(FLAGS['REJECTED']);
-    csvDumpResponse('rejected-matches', $rejected);
+if(isset($_GET['dump']) && array_key_exists($_GET['dump'], FLAGS)){
+    $match_flag = $_GET['dump'];
+    $matches = $getMatches(FLAGS[$match_flag]);
+    csvDumpResponse(strtolower($match_flag) . '-matches', $matches);
     exit();
 }
 

--- a/wikidata_game/views/stats-page.php
+++ b/wikidata_game/views/stats-page.php
@@ -25,7 +25,7 @@
             <strong>Acceptance Rate</strong>: <?php echo $acceptance_rate ?>%
         </li>
     </ul>
-    <p><a href="?dump=REJECTED" download>Download Rejected Matches (CSV)</a></p>
     <p><a href="?dump=ACCEPTED" download>Download Accepted Matches (CSV)</a></p>
+    <p><a href="?dump=REJECTED" download>Download Rejected Matches (CSV)</a></p>
 </body>
 </html>

--- a/wikidata_game/views/stats-page.php
+++ b/wikidata_game/views/stats-page.php
@@ -25,6 +25,6 @@
             <strong>Acceptance Rate</strong>: <?php echo $acceptance_rate ?>%
         </li>
     </ul>
-    <p><a href="?dump=rejected" download>Download Rejected Matches (CSV)</a></p>
+    <p><a href="?dump=REJECTED" download>Download Rejected Matches (CSV)</a></p>
 </body>
 </html>

--- a/wikidata_game/views/stats-page.php
+++ b/wikidata_game/views/stats-page.php
@@ -26,5 +26,6 @@
         </li>
     </ul>
     <p><a href="?dump=REJECTED" download>Download Rejected Matches (CSV)</a></p>
+    <p><a href="?dump=ACCEPTED" download>Download Accepted Matches (CSV)</a></p>
 </body>
 </html>


### PR DESCRIPTION
As requested this morning, this change makes accepted matches available for download.

To validate go to: https://wd-ref-island.toolforge.org/stats.php and makes sure the correct data is available for download